### PR TITLE
bugfix, reduce delay time afer write string, using strlen to generate…

### DIFF
--- a/src/SerLCD.c
+++ b/src/SerLCD.c
@@ -307,14 +307,14 @@ uint8_t displayWrite(uint8_t b)
  * @retval	status 	- 0...OK, other...error
  *
  */
-uint8_t displayWriteString(char *buffer, uint16_t size)
+uint8_t displayWriteString(char *buffer)
 {
 	uint8_t retval = LCD_OK;
 
 	// transmission of data stream
-	if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, buffer, size, 100) != HAL_OK)		// transmit data
+	if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, buffer, strlen(buffer), 100) != HAL_OK)		// transmit data
 	  retval = LCD_ERROR;
-	HAL_Delay(50); //This takes a bit longer
+	HAL_Delay(10); //This takes a bit longer
 
     return retval;
 }
@@ -346,7 +346,7 @@ uint8_t displayCreateChar(uint8_t location, uint8_t *charmap)
   	  	  	  	  	  	  	 };
 
   // transmission of data stream
-  if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+  if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
 	  retval = LCD_ERROR;
   HAL_Delay(50); //This takes a bit longer
 
@@ -496,7 +496,7 @@ uint8_t displayEnableSystemMessages()
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -520,7 +520,7 @@ uint8_t displayDisableSystemMessages()
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -544,7 +544,7 @@ uint8_t displayDisableSystemMessages()
  * @param  	b 		- 0...255
  * @retval	status 	- 0...OK, other...error
  */
-uint8_t displaySetBacklight(uint8_t r, uint8_t g, uint8_t b)
+uint8_t displaySetBacklight(uint16_t r, uint16_t g, uint16_t b)
 {
 	uint8_t retval = LCD_OK;
 
@@ -559,14 +559,14 @@ uint8_t displaySetBacklight(uint8_t r, uint8_t g, uint8_t b)
 	// create i2c data stream
     uint8_t TransmitData[10] = {SPECIAL_COMMAND,								//Send special command character
     						    LCD_DISPLAYCONTROL |(_displayControl & ~LCD_DISPLAYON), // turn display off
-    						    SETTING_COMMAND, (128 + r),						// red: 0...100% ~ 0...29
-    						    SETTING_COMMAND, (158 + g), 					// green: 0...100% ~ 0...29
-							    SETTING_COMMAND, (188 + b), 					// blue: 0...100% ~ 0...29
+    						    SETTING_COMMAND, (128 + (uint8_t)r),						// red: 0...100% ~ 0...29
+    						    SETTING_COMMAND, (158 + (uint8_t)g), 					// green: 0...100% ~ 0...29
+							    SETTING_COMMAND, (188 + (uint8_t)b), 					// blue: 0...100% ~ 0...29
 								SPECIAL_COMMAND,                      			//Send special command character
 								LCD_DISPLAYCONTROL | (_displayControl |= LCD_DISPLAYON)}; // turn display off as before
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(50);
 
@@ -596,7 +596,7 @@ uint8_t displaySetFastBacklight(uint8_t r, uint8_t g, uint8_t b)
     						   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -621,7 +621,7 @@ uint8_t displaySetContrast(uint8_t new_val)
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -649,7 +649,7 @@ uint8_t displaySetAddress(uint8_t new_addr)
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
 
     //Update our own address so we can still talk to the display
@@ -684,7 +684,7 @@ uint8_t displayEnableSplash()
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -707,7 +707,7 @@ uint8_t displayDisableSplash()
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -730,7 +730,7 @@ uint8_t displaySaveSplash()
 							   };
 
     // transmission of data stream
-    if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+    if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
     	retval = LCD_ERROR;
     HAL_Delay(10);
 
@@ -755,7 +755,7 @@ uint8_t displayCommand(uint8_t command)
 {
 	uint8_t retval = LCD_OK;
 	uint8_t TransmitData[2] = {SETTING_COMMAND, command}; 												// create data stream
-	if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+	if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
 		retval = LCD_ERROR;
 	HAL_Delay(10); //Wait a bit longer for special display commands
 	return retval;
@@ -771,7 +771,7 @@ uint8_t displaySpecialCommand(uint8_t command)
 {
 	uint8_t retval = LCD_OK;
 	uint8_t TransmitData[2] = {SPECIAL_COMMAND, command}; 												// create data stream
-	if(HAL_I2C_Master_Transmit(&_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
+	if(HAL_I2C_Master_Transmit(_i2cHandler, DISPLAY_ADDRESS1<<1, TransmitData, sizeof(TransmitData), 100) != HAL_OK)		// transmit data
 		retval = LCD_ERROR;
 	HAL_Delay(50); //Wait a bit longer for special display commands
 	return retval;

--- a/src/SerLCD.h
+++ b/src/SerLCD.h
@@ -81,7 +81,7 @@ uint8_t displayNoAutoscroll();
 /* write on the display */
 uint8_t displayClear();
 uint8_t displayWrite(uint8_t b);
-uint8_t displayWriteString(char *buffer, uint16_t size);
+uint8_t displayWriteString(char *buffer);
 uint8_t displayCreateChar(uint8_t location, uint8_t *charmap);
 uint8_t displayWriteChar(uint8_t location);
 
@@ -100,7 +100,7 @@ uint8_t displayEnableSystemMessages();
 uint8_t displayDisableSystemMessages();
 
 /* display properties */
-uint8_t displaySetBacklight(uint8_t r, uint8_t g, uint8_t b);
+uint8_t displaySetBacklight(uint16_t r, uint16_t g, uint16_t b);
 uint8_t displaySetFastBacklight(uint8_t r, uint8_t g, uint8_t b);
 uint8_t displaySetContrast(uint8_t new_val);
 uint8_t displaySetAddress(uint8_t new_addr);


### PR DESCRIPTION
… buffer length in writeString

- bugfix: remove reference from HAL I2C transmitt function, replace uint8_t datatype for rgb to uint16_t.
- reduce delay time afer write string for an higher performance
- using strlen to generate buffer length in writeString function to automate use the correct buffer length